### PR TITLE
Proposta de alteração na documentação referente aos contratos.

### DIFF
--- a/AddressDiscovery.md
+++ b/AddressDiscovery.md
@@ -23,17 +23,17 @@ _Mapping_ do endereço dos contratos, a chave é o hash keccak256 do nome do con
 ### constructor
 
 ```solidity
-constructor(address _authority, address _admin) public
+constructor(address _authority, address _admin)
 ```
 
 Construtor
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _authority | address | Autoridade do contrato, pode atualizar os endereços dos contratos. |
-| _admin | address | Administrador, pode trocar a autoridade. |
+| Name        | Type    | Description                                                        |
+| ----------- | ------- | ------------------------------------------------------------------ |
+| \_authority | address | Autoridade do contrato, pode atualizar os endereços dos contratos. |
+| \_admin     | address | Administrador, pode trocar a autoridade.                           |
 
 ### updateAddress
 
@@ -45,8 +45,7 @@ Atualiza o endereço de um contrato, permitido apenas para a autoridade.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                         |
+| ------------- | ------- | ----------------------------------- |
 | smartContract | bytes32 | Hash keccak256 do nome do contrato. |
-| newAddress | address | Novo endereço do contrato. |
-
+| newAddress    | address | Novo endereço do contrato.          |

--- a/CBDCAccessControl.md
+++ b/CBDCAccessControl.md
@@ -5,6 +5,7 @@
 _Smart Contract_ responsável pela camada de controle de acesso para o Real Digital/Tokenizado.
 
 Suas principais funcionalidades são:
+
 - Determinar quais carteiras podem enviar/receber tokens.
 - Controlar os papeis de qual endereço pode emitir/resgatar/congelar saldo de uma carteira.
 
@@ -74,8 +75,8 @@ Evento de carteira habilitada.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description         |
+| ------ | ------- | ------------------- |
 | member | address | Carteira habilitada |
 
 ### DisabledAccount
@@ -88,24 +89,24 @@ Evento de carteira desabilitada.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description           |
+| ------ | ------- | --------------------- |
 | member | address | Carteira desabilitada |
 
 ### constructor
 
 ```solidity
-constructor(address _authority, address _admin) internal
+constructor(address _authority, address _admin)
 ```
 
 Constrói uma instância da contrato, armazenando os argumentos informados.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _authority | address | Autoridade do contrato, pode fazer todas as operações com o token |
-| _admin | address | Administrador do contrato, pode trocar a autoridade do contrato caso seja necessário |
+| Name        | Type    | Description                                                                          |
+| ----------- | ------- | ------------------------------------------------------------------------------------ |
+| \_authority | address | Autoridade do contrato, pode fazer todas as operações com o token                    |
+| \_admin     | address | Administrador do contrato, pode trocar a autoridade do contrato caso seja necessário |
 
 ### checkAccess
 
@@ -117,10 +118,10 @@ Modificador que checa se tanto o pagador quanto o recebedor estão habilitados a
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| from | address | Carteira do pagador |
-| to | address | Carteira do recebedor |
+| Name | Type    | Description           |
+| ---- | ------- | --------------------- |
+| from | address | Carteira do pagador   |
+| to   | address | Carteira do recebedor |
 
 ### enableAccount
 
@@ -132,8 +133,8 @@ Habilita a carteira a receber o token.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description               |
+| ------ | ------- | ------------------------- |
 | member | address | Carteira a ser habilitada |
 
 ### disableAccount
@@ -146,8 +147,8 @@ Desabilita a carteira.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                 |
+| ------ | ------- | --------------------------- |
 | member | address | Carteira a ser desabilitada |
 
 ### verifyAccount
@@ -160,7 +161,6 @@ Checa se a carteira pode receber o token.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description            |
+| ------- | ------- | ---------------------- |
 | account | address | Carteira a ser checada |
-

--- a/KeyDictionary.md
+++ b/KeyDictionary.md
@@ -55,7 +55,7 @@ Modificador de método: somente participantes podem executar o método.
 ### constructor
 
 ```solidity
-constructor(contract RealDigital token)
+constructor(RealDigital token)
 ```
 
 Constrói uma instância do contrato e armazena o endereço do contrato do Real Digital.

--- a/KeyDictionary.md
+++ b/KeyDictionary.md
@@ -4,7 +4,7 @@
 
 Contrato que representa a consulta de carteiras de clientes. É um contrato de simulação de um diretório de informações.
 
-Este contrato será usado somente durante o piloto. 
+Este contrato será usado somente durante o piloto.
 
 ### CBDC
 
@@ -21,7 +21,7 @@ struct CustomerData {
   uint256 taxId;      // O CPF do cliente
   uint256 bankNumber; // O código da participante
   uint256 account;    // A conta do cliente
-  uint256 branch;     // A agência do cliente   
+  uint256 branch;     // A agência do cliente
   address wallet;     // A carteira do cliente
   bool registered;    // Registrado ou não
   address owner;      // A carteira do participante que inseriu o cliente
@@ -38,11 +38,11 @@ Evento de solicitação de troca de dono de chave.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| owner | address | O atual dono da chave |
-| proposalId | uint256 | Id da proposta |
-| key | bytes32 | A chave |
+| Name       | Type    | Description           |
+| ---------- | ------- | --------------------- |
+| owner      | address | O atual dono da chave |
+| proposalId | uint256 | Id da proposta        |
+| key        | bytes32 | A chave               |
 
 ### onlyParticipant
 
@@ -52,22 +52,19 @@ modifier onlyParticipant()
 
 Modificador de método: somente participantes podem executar o método.
 
-
 ### constructor
 
 ```solidity
-constructor(contract RealDigital token) public
+constructor(contract RealDigital token)
 ```
 
 Constrói uma instância do contrato e armazena o endereço do contrato do Real Digital.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type                 | Description                          |
+| ----- | -------------------- | ------------------------------------ |
 | token | contract RealDigital | Endereço do contrato do Real Digital |
-
-
 
 ### addAccount
 
@@ -79,14 +76,14 @@ Adiciona os dados do cliente, vinculando à chave _key_.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| key | bytes32 | A chave |
-| _taxId | uint256 | O CPF do cliente |
-| _bankNumber | uint256 | O ID do participante |
-| _account | uint256 | A conta do cliente |
-| _branch | uint256 | A agência do cliente |
-| _wallet | address | A carteira do cliente |
+| Name         | Type    | Description           |
+| ------------ | ------- | --------------------- |
+| key          | bytes32 | A chave               |
+| \_taxId      | uint256 | O CPF do cliente      |
+| \_bankNumber | uint256 | O ID do participante  |
+| \_account    | uint256 | A conta do cliente    |
+| \_branch     | uint256 | A agência do cliente  |
+| \_wallet     | address | A carteira do cliente |
 
 ### getWallet
 
@@ -98,10 +95,9 @@ Retorna a carteira do cliente com base na sua chave _key_.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| key | bytes32 | A chave cuja carteira está sendo buscada |
-
+| Name | Type    | Description                              |
+| ---- | ------- | ---------------------------------------- |
+| key  | bytes32 | A chave cuja carteira está sendo buscada |
 
 ### getKey
 
@@ -113,11 +109,9 @@ Retorna a chave do cliente com base na sua carteira.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description           |
+| ------ | ------- | --------------------- |
 | wallet | address | A carteira do cliente |
-
-
 
 ### getCustomerData
 
@@ -129,9 +123,9 @@ Retorna todos os dados do cliente.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| key | bytes32 | A chave do cliente solicitado |
+| Name | Type    | Description                   |
+| ---- | ------- | ----------------------------- |
+| key  | bytes32 | A chave do cliente solicitado |
 
 ### updateData
 
@@ -143,14 +137,14 @@ Atualiza os dados do cliente vinculado à chave _key_. Apenas o dono da carteira
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| key | bytes32 | A nova chave do cliente |
-| _taxId | uint256 | O novo CPF do cliente |
-| _bankNumber | uint256 | O novo ID do participante responsável pelo cliente |
-| _account | uint256 | A nova conta do cliente |
-| _branch | uint256 | A nova agência do cliente |
-| _wallet | address | A nova carteira do cliente |
+| Name         | Type    | Description                                        |
+| ------------ | ------- | -------------------------------------------------- |
+| key          | bytes32 | A nova chave do cliente                            |
+| \_taxId      | uint256 | O novo CPF do cliente                              |
+| \_bankNumber | uint256 | O novo ID do participante responsável pelo cliente |
+| \_account    | uint256 | A nova conta do cliente                            |
+| \_branch     | uint256 | A nova agência do cliente                          |
+| \_wallet     | address | A nova carteira do cliente                         |
 
 ### requestKey
 
@@ -162,14 +156,14 @@ Requisita uma chave que pertence a outro participante.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| key | bytes32 | A chave requisitada |
-| _taxId | uint256 | O CPF do cliente requisitante |
-| _bankNumber | uint256 | ID do participante responsável pelo cliente requisitante |
-| _account | uint256 | A conta do cliente requisitante |
-| _branch | uint256 | A agência do cliente requisitante |
-| _wallet | address | A carteira do cliente requisitante |
+| Name         | Type    | Description                                              |
+| ------------ | ------- | -------------------------------------------------------- |
+| key          | bytes32 | A chave requisitada                                      |
+| \_taxId      | uint256 | O CPF do cliente requisitante                            |
+| \_bankNumber | uint256 | ID do participante responsável pelo cliente requisitante |
+| \_account    | uint256 | A conta do cliente requisitante                          |
+| \_branch     | uint256 | A agência do cliente requisitante                        |
+| \_wallet     | address | A carteira do cliente requisitante                       |
 
 ### authorizeKey
 
@@ -181,8 +175,7 @@ Autoriza a alteração de dados proposta pelo id _proposalId_ para a chave _key_
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | Id da proposta |
-| key | bytes32 | A chave cujos dados serão alterados |
-
+| Name       | Type    | Description                         |
+| ---------- | ------- | ----------------------------------- |
+| proposalId | uint256 | Id da proposta                      |
+| key        | bytes32 | A chave cujos dados serão alterados |

--- a/RealDigital.md
+++ b/RealDigital.md
@@ -2,7 +2,6 @@
 
 ## RealDigital
 
-
 ### frozenBalanceOf
 
 ```solidity
@@ -21,10 +20,10 @@ Evento emitido quando um valor de uma carteira é congelado.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                         |
+| ------ | ------- | ----------------------------------- |
 | wallet | address | carteira que teve o fundo congelado |
-| amount | uint256 | quantidade congelada |
+| amount | uint256 | quantidade congelada                |
 
 ### checkFrozenBalance
 
@@ -37,7 +36,7 @@ _Modifier_ para verificar se um endereço possui fundos suficientes. Usado no `_
 ### constructor
 
 ```solidity
-constructor(string _name, string _symbol, address _authority, address _admin) public
+constructor(string _name, string _symbol, address _authority, address _admin)
 ```
 
 Construtor do token do Real Digital.
@@ -46,15 +45,12 @@ Invoca o construtor do ERC20 e dá permissão de autoridade para a carteira do B
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _name | string | Nome do token: Real Digital |
-| _symbol | string | Símbolo do token: BRL |
-| _authority | address | Carteira responsável por emitir, resgatar, mover e congelar fundos (BCB) |
-| _admin | address | Carteira responsável por administrar o controle de acessos (BCB) |
-
-
-
+| Name        | Type    | Description                                                              |
+| ----------- | ------- | ------------------------------------------------------------------------ |
+| \_name      | string  | Nome do token: Real Digital                                              |
+| \_symbol    | string  | Símbolo do token: BRL                                                    |
+| \_authority | address | Carteira responsável por emitir, resgatar, mover e congelar fundos (BCB) |
+| \_admin     | address | Carteira responsável por administrar o controle de acessos (BCB)         |
 
 ### pause
 
@@ -82,12 +78,12 @@ Função para emitir tokens para as carteiras permitidas.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| to | address | carteira destino |
+| Name   | Type    | Description          |
+| ------ | ------- | -------------------- |
+| to     | address | carteira destino     |
 | amount | uint256 | quantidade de tokens |
 
-### _beforeTokenTransfer
+### \_beforeTokenTransfer
 
 ```solidity
 function _beforeTokenTransfer(address from, address to, uint256 amount) internal
@@ -98,7 +94,7 @@ Gatilho executado sempre que é solicitada uma movimentação de token, inclusiv
 Condições de chamada:
 
 - quando `from` é zero, `amount` tokens serão emitidos `to`.
-- quando  `to` é zero, `amount` do `from` tokens serão destruídos.
+- quando `to` é zero, `amount` do `from` tokens serão destruídos.
 - `from` e `to` nunca serão simultaneamente zero.
 - `from` e `to` devem estar registrados como participantes.
 
@@ -120,10 +116,10 @@ Função para mover tokens de uma carteira para outra. Somente quem possuir MOVE
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| from | address | carteira origem |
-| to | address | carteira destino |
+| Name   | Type    | Description          |
+| ------ | ------- | -------------------- |
+| from   | address | carteira origem      |
+| to     | address | carteira destino     |
 | amount | uint256 | quantidade de tokens |
 
 ### increaseFrozenBalance
@@ -136,9 +132,9 @@ Função para incrementar tokens parcialmente bloqueados de uma carteira. Soment
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| from | address | carteira origem |
+| Name   | Type    | Description          |
+| ------ | ------- | -------------------- |
+| from   | address | carteira origem      |
 | amount | uint256 | quantidade de tokens |
 
 ### decreaseFrozenBalance
@@ -151,9 +147,9 @@ Função para decrementar tokens parcialmente bloqueados de uma carteira. Soment
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| from | address | carteira origem |
+| Name   | Type    | Description          |
+| ------ | ------- | -------------------- |
+| from   | address | carteira origem      |
 | amount | uint256 | quantidade de tokens |
 
 ### burn
@@ -176,9 +172,9 @@ Função para destruir tokens de uma carteira. Somente quem possuir MOVER_ROLE p
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| from | address | carteira origem |
+| Name   | Type    | Description          |
+| ------ | ------- | -------------------- |
+| from   | address | carteira origem      |
 | amount | uint256 | quantidade de tokens |
 
 ### burnFrom
@@ -187,11 +183,10 @@ Função para destruir tokens de uma carteira. Somente quem possuir MOVER_ROLE p
 function burnFrom(address account, uint256 amount) public
 ```
 
-Destrói `amount` tokens da  `account`, deduzindo alllowance do executor.
-Olhe {ERC20-_burn} e {ERC20-allowance}.
+Destrói `amount` tokens da `account`, deduzindo alllowance do executor.
+Olhe {ERC20-\_burn} e {ERC20-allowance}.
 
 Requerimentos:
 
-- o executor deve possuir autorização de mover fundos da  `accounts` de no mínimo o
-`amount`.
-
+- o executor deve possuir autorização de mover fundos da `accounts` de no mínimo o
+  `amount`.

--- a/RealDigitalDefaultAccount.md
+++ b/RealDigitalDefaultAccount.md
@@ -39,7 +39,7 @@ Modificador de método: somente participantes podem alterar suas carteiras _defa
 ### constructor
 
 ```solidity
-constructor(RealDigital token, address _authority, address _admin) public
+constructor(RealDigital token, address _authority, address _admin)
 ```
 
 #### Parameters

--- a/RealDigitalDefaultAccount.md
+++ b/RealDigitalDefaultAccount.md
@@ -12,7 +12,6 @@ bytes32 ACCESS_ROLE
 
 _Role_ de acesso pertencente à autoridade do contrato.
 
-
 ### CBDC
 
 ```solidity
@@ -20,7 +19,6 @@ contract RealDigital CBDC
 ```
 
 Referência ao contrato do Real Digital para validação de participantes.
-
 
 ### defaultAccount
 
@@ -30,7 +28,6 @@ mapping(uint256 => address) defaultAccount
 
 _Mapping_ das contas default. Chave é o CPNJ8 do participante.
 
-
 ### onlyParticipant
 
 ```solidity
@@ -39,23 +36,19 @@ modifier onlyParticipant()
 
 Modificador de método: somente participantes podem alterar suas carteiras _default_.
 
-
 ### constructor
 
 ```solidity
-constructor(contract RealDigital token, address _authority, address _admin) public
+constructor(RealDigital token, address _authority, address _admin) public
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | contract RealDigital | Endereço do Real Digital |
-| _authority | address | Autoridade do contrato. Adiciona carteiras default |
-| _admin | address | Administrador do contrato. Permite trocar a autoridade |
-
-
-
+| Name        | Type                 | Description                                            |
+| ----------- | -------------------- | ------------------------------------------------------ |
+| token       | contract RealDigital | Endereço do Real Digital                               |
+| \_authority | address              | Autoridade do contrato. Adiciona carteiras default     |
+| \_admin     | address              | Administrador do contrato. Permite trocar a autoridade |
 
 ### addDefaultAccount
 
@@ -67,13 +60,10 @@ Adiciona a primeira carteira _default_ para um participante. É permitido apenas
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| cnpj8 | uint256 | CNPJ8 do participante |
-| wallet | address | Carteira |
-
-
-
+| Name   | Type    | Description           |
+| ------ | ------- | --------------------- |
+| cnpj8  | uint256 | CNPJ8 do participante |
+| wallet | address | Carteira              |
 
 ### updateDefaultWallet
 
@@ -81,12 +71,11 @@ Adiciona a primeira carteira _default_ para um participante. É permitido apenas
 function updateDefaultWallet(uint256 cnpj8, address newWallet) public
 ```
 
-Permite ao participante trocar sua carteira _default_. 
+Permite ao participante trocar sua carteira _default_.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| cnpj8 | uint256 | CNPJ8 do participante |
-| newWallet | address | Carteira |
-
+| Name      | Type    | Description           |
+| --------- | ------- | --------------------- |
+| cnpj8     | uint256 | CNPJ8 do participante |
+| newWallet | address | Carteira              |

--- a/RealDigitalEnableAccount.md
+++ b/RealDigitalEnableAccount.md
@@ -4,25 +4,19 @@
 
 Contrato que permite ao participante habilitar outras carteiras de sua propriedade.
 
-
-
-
 ### constructor
 
 ```solidity
-constructor(address accessControlAddress) public
+constructor(address accessControlAddress)
 ```
 
 Constrói uma instância do contrato e armazena o endereço do contrato do RealDigital, responsável pelas verificações de controle de acesso.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name                 | Type    | Description                                |
+| -------------------- | ------- | ------------------------------------------ |
 | accessControlAddress | address | Endereço do contrato de controle de acesso |
-
-
-
 
 ### enableAccount
 
@@ -34,12 +28,9 @@ Habilita uma nova carteira para o participante. Qualquer carteira previamente ha
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                   |
+| ------ | ------- | ----------------------------- |
 | member | address | Novo endereço do participante |
-
-
-
 
 ### disableAccount
 
@@ -48,4 +39,3 @@ function disableAccount() public
 ```
 
 Desabilita a própria carteira que executou a função.
-

--- a/RealTokenizado.md
+++ b/RealTokenizado.md
@@ -11,6 +11,7 @@ Este contrato herda do Real Digital e todas as funções implementadas.
 ```solidity
 string participant
 ```
+
 _String_ que representa o nome do participante.
 
 ### cnpj8
@@ -18,6 +19,7 @@ _String_ que representa o nome do participante.
 ```solidity
 uint256 cnpj8
 ```
+
 _Uitn256_ que representa o número da instituição.
 
 ### reserve
@@ -25,13 +27,13 @@ _Uitn256_ que representa o número da instituição.
 ```solidity
 address reserve
 ```
-Carteira de reserva da instituição participante.
 
+Carteira de reserva da instituição participante.
 
 ### constructor
 
 ```solidity
-constructor(string _name, string _symbol, address _authority, address _admin, string _participant, uint256 _cnpj8, address _reserve) public
+constructor(string _name, string _symbol, address _authority, address _admin, string _participant, uint256 _cnpj8, address _reserve)
 ```
 
 Construtor do token do Real Tokenizado.
@@ -40,16 +42,15 @@ Invoca o construtor do ERC20 e dá permissão de autoridade para a carteira do B
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _name | string | Nome do token: Real Tokenizado (Instituiçâo) |
-| _symbol | string | Símbolo do token: BRL |
-| _authority | address | Carteira responsável por emitir, resgatar, mover e congelar fundos (BCB) |
-| _admin | address | Carteira responsável por administrar o controle de acessos (BCB) |
-| _participant | string | Identificação do participante como string. |
-| _cnpj8 | uint256 | Primeiros 8 digitos do CNPJ da instituição |
-| _reserve | address | Carteira de reserva da instituição |
-
+| Name          | Type    | Description                                                              |
+| ------------- | ------- | ------------------------------------------------------------------------ |
+| \_name        | string  | Nome do token: Real Tokenizado (Instituiçâo)                             |
+| \_symbol      | string  | Símbolo do token: BRL                                                    |
+| \_authority   | address | Carteira responsável por emitir, resgatar, mover e congelar fundos (BCB) |
+| \_admin       | address | Carteira responsável por administrar o controle de acessos (BCB)         |
+| \_participant | string  | Identificação do participante como string.                               |
+| \_cnpj8       | uint256 | Primeiros 8 digitos do CNPJ da instituição                               |
+| \_reserve     | address | Carteira de reserva da instituição                                       |
 
 ### updateReserve
 
@@ -59,10 +60,8 @@ function updateReserve(address newReserve) public
 
 Função para atualizar a carteira de reserva do token. A carteira de reserva é usada pelo DvP
 
-
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description                          |
+| ---------- | ------- | ------------------------------------ |
 | newReserve | address | Carteira da autoridade (Instituição) |
-

--- a/STR.md
+++ b/STR.md
@@ -25,7 +25,7 @@ Modificador de método: somente participantes podem executar a função
 ### constructor
 
 ```solidity
-constructor(contract RealDigital token)
+constructor(RealDigital token)
 ```
 
 Constrói uma instância do contrato e armazena o endereço do Real Digital

--- a/STR.md
+++ b/STR.md
@@ -25,15 +25,15 @@ Modificador de método: somente participantes podem executar a função
 ### constructor
 
 ```solidity
-constructor(contract RealDigital token) public
+constructor(contract RealDigital token)
 ```
 
 Constrói uma instância do contrato e armazena o endereço do Real Digital
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type                 | Description              |
+| ----- | -------------------- | ------------------------ |
 | token | contract RealDigital | Endereço do Real Digital |
 
 ### requestToMint
@@ -46,8 +46,8 @@ Emite a quantidade de Real Digital informada em _amount_ para a própria carteir
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                                                  |
+| ------ | ------- | ------------------------------------------------------------ |
 | amount | uint256 | Quantidade a ser emitida (obs: lembrar das 2 casas decimais) |
 
 ### requestToBurn
@@ -60,7 +60,6 @@ Destrói a quantidade de Real Digital informada em _amount_ da própria carteira
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                                                    |
+| ------ | ------- | -------------------------------------------------------------- |
 | amount | uint256 | Quantidade a ser destruída (obs: lembrar das 2 casas decimais) |
-

--- a/SwapOneStep.md
+++ b/SwapOneStep.md
@@ -4,12 +4,11 @@
 
 Este contrato implementa a troca de Real Tokenizado entre dois participantes distintos.
 
-A troca destrói Real Tokenizado do cliente pagador, 
+A troca destrói Real Tokenizado do cliente pagador,
 transfere Real Digital do participante pagador para o participante recebedor
 e emite Real Tokenizado para o cliente recebedor.
 
 Todos os passos dessa operação de _swap_ são realizados em apenas uma transação.
-
 
 ### CBDC
 
@@ -18,7 +17,6 @@ contract RealDigital CBDC
 ```
 
 Referência ao contrato para que seja efetuada a movimentação de Real Digital.
-
 
 ### SwapExecuted
 
@@ -30,29 +28,27 @@ Evento de _swap_ executado.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| senderNumber | uint256 | O CNPJ8 do pagador |
-| receiverNumber | uint256 | O CNPJ8 do recebedor |
-| sender | address | A carteira do pagador |
-| receiver | address | A carteira do recebedor |
-| amount | uint256 | O valor que foi movimentado |
+| Name           | Type    | Description                 |
+| -------------- | ------- | --------------------------- |
+| senderNumber   | uint256 | O CNPJ8 do pagador          |
+| receiverNumber | uint256 | O CNPJ8 do recebedor        |
+| sender         | address | A carteira do pagador       |
+| receiver       | address | A carteira do recebedor     |
+| amount         | uint256 | O valor que foi movimentado |
 
 ### constructor
 
 ```solidity
-constructor(contract RealDigital _CBDC) public
+constructor(contract RealDigital _CBDC)
 ```
 
 Constrói uma instância do contrato e armazena o endereço do contrato do Real Digital.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _CBDC | contract RealDigital | Endereço do contrato do Real Digital |
-
-
+| Name   | Type                 | Description                          |
+| ------ | -------------------- | ------------------------------------ |
+| \_CBDC | contract RealDigital | Endereço do contrato do Real Digital |
 
 ### executeSwap
 
@@ -64,10 +60,9 @@ Transfere o Real Tokenizado do cliente pagador para o recebedor. O cliente pagad
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenSender | contract RealTokenizado | O endereço do contrato de Real Tokenizado do participante pagador |
+| Name          | Type                    | Description                                                         |
+| ------------- | ----------------------- | ------------------------------------------------------------------- |
+| tokenSender   | contract RealTokenizado | O endereço do contrato de Real Tokenizado do participante pagador   |
 | tokenReceiver | contract RealTokenizado | O endereço do contrato de Real Tokenizado do participante recebedor |
-| receiver | address | O endereço do cliente recebedor |
-| amount | uint256 | O valor a ser movimentado |
-
+| receiver      | address                 | O endereço do cliente recebedor                                     |
+| amount        | uint256                 | O valor a ser movimentado                                           |

--- a/SwapTwoSteps.md
+++ b/SwapTwoSteps.md
@@ -60,14 +60,14 @@ Evento de início do _swap_.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | Id da proposta |
-| senderNumber | uint256 | CNPJ8 do pagador |
-| receiverNumber | uint256 | CNPJ8 do recebedor |
-| sender | address | Endereço do pagador |
-| receiver | address | Endereço do recebedor |
-| amount | uint256 | Valor |
+| Name           | Type    | Description           |
+| -------------- | ------- | --------------------- |
+| proposalId     | uint256 | Id da proposta        |
+| senderNumber   | uint256 | CNPJ8 do pagador      |
+| receiverNumber | uint256 | CNPJ8 do recebedor    |
+| sender         | address | Endereço do pagador   |
+| receiver       | address | Endereço do recebedor |
+| amount         | uint256 | Valor                 |
 
 ### SwapExecuted
 
@@ -79,14 +79,14 @@ Evento de _swap_ executado.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | Id da proposta |
-| senderNumber | uint256 | CNPJ8 do pagador |
-| receiverNumber | uint256 | CNPJ8 do recebedor |
-| sender | address | Endereço do pagador |
-| receiver | address | Endereço do recebedor |
-| amount | uint256 | Valor |
+| Name           | Type    | Description           |
+| -------------- | ------- | --------------------- |
+| proposalId     | uint256 | Id da proposta        |
+| senderNumber   | uint256 | CNPJ8 do pagador      |
+| receiverNumber | uint256 | CNPJ8 do recebedor    |
+| sender         | address | Endereço do pagador   |
+| receiver       | address | Endereço do recebedor |
+| amount         | uint256 | Valor                 |
 
 ### SwapCancelled
 
@@ -98,10 +98,10 @@ Evento de _swap_ cancelado.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | Id da proposta |
-| reason | string | Razão do cancelamento |
+| Name       | Type    | Description           |
+| ---------- | ------- | --------------------- |
+| proposalId | uint256 | Id da proposta        |
+| reason     | string  | Razão do cancelamento |
 
 ### ExpiredProposal
 
@@ -113,23 +113,23 @@ Evento de proposta expirada. A proposta expira em 1 minuto.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description    |
+| ---------- | ------- | -------------- |
 | proposalId | uint256 | Id da proposta |
 
 ### constructor
 
 ```solidity
-constructor(contract RealDigital _CBDC) public
+constructor(contract RealDigital _CBDC)
 ```
 
 Construtor
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _CBDC | contract RealDigital | Endereço do contrato do Real Digital |
+| Name   | Type                 | Description                          |
+| ------ | -------------------- | ------------------------------------ |
+| \_CBDC | contract RealDigital | Endereço do contrato do Real Digital |
 
 ### startSwap
 
@@ -141,12 +141,12 @@ Cria a proposta de _swap_.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenSender | contract RealTokenizado | Endereço do contrato de Real Tokenizado do pagador |
+| Name          | Type                    | Description                                          |
+| ------------- | ----------------------- | ---------------------------------------------------- |
+| tokenSender   | contract RealTokenizado | Endereço do contrato de Real Tokenizado do pagador   |
 | tokenReceiver | contract RealTokenizado | Endereço do contrato de Real Tokenizado do recebedor |
-| receiver | address | Endereço do cliente recebedor |
-| amount | uint256 | Valor |
+| receiver      | address                 | Endereço do cliente recebedor                        |
+| amount        | uint256                 | Valor                                                |
 
 ### executeSwap
 
@@ -158,8 +158,8 @@ Aceita a proposta de _swap_, executável apenas pelo recebedor.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description    |
+| ---------- | ------- | -------------- |
 | proposalId | uint256 | Id da proposta |
 
 ### cancelSwap
@@ -172,8 +172,7 @@ Cancela a proposta. Pode ser executada tanto pelo pagador quanto pelo recebedor.
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | Id da proposta |
-| reason | string | Razão do cancelamento |
-
+| Name       | Type    | Description           |
+| ---------- | ------- | --------------------- |
+| proposalId | uint256 | Id da proposta        |
+| reason     | string  | Razão do cancelamento |


### PR DESCRIPTION
## Nota
Sei que a documentação é gerada automaticamente utilizando os comentários NatSpec.
Porem, da para fazer as alterações proposta neste PR na mão.

## Proposta de alteração na documentação.

Foi removido apenas uma sintaxe incorreta na tipagem e na visibilidade.

Antes

```js
constructor(contract RealDigital token, address _authority, address _admin) public

```

Depois de remover o `contract` da tipagem do parâmetro `RealDigital token, address` e na visibilidade `public`

```js
constructor(RealDigital token, address _authority, address _admin)
```
