### PR TITLE
RealDigitalDefaultAccount - padronização de input names entre getter e setter do DefaultAccount

### DIFF
--- a/abi/RealDigitalDefaultAccount.json
+++ b/abi/RealDigitalDefaultAccount.json
@@ -133,7 +133,7 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "cnpj8",
         "type": "uint256"
       }
     ],


### PR DESCRIPTION
O primeiro input para a function `addDefaultAccount` do ABI `RealDigitalDefaultAccount.json` está especificando o `name` como:
```json
"name": "cnpj8",
```

Já a function `defaultAccount` não especifica qual é o name de seu input:
```json
  {
    "inputs": [
      {
        "internalType": "uint256",
        "name": "",
        "type": "uint256"
      }
    ],
    "name": "defaultAccount",
    ...
  },
```
Essa falta de definição ocorre porque a function é automaticamente gerada pelo Solidity, devido à existência de um mapping público denominado `defaultAccount`.

Sugiro a definição manual do atributo `name` no ABI da function `defaultAccount`, assim fica claro para todos qual é o input esperado para a function.