### PR TITLE
fix: wait for transaction confirmation

### DIFF
--- a/exemplos/example1.ts
+++ b/exemplos/example1.ts
@@ -3,10 +3,6 @@ import abiSTR from "../abi/STR.json";
 import abiRealDigitalEnableAccount from "../abi/RealDigitalEnableAccount.json";
 import { TransactionReceipt, TransactionResponse } from "@ethersproject/providers";
 
-function delay(ms: number) {
-    return new Promise( resolve => setTimeout(resolve, ms) );
-};
-
 // Habilita uma conta, emite valores e destrói valores.
 async function example1() {
     const STR = await ethers.getContractAt(abiSTR, '<Endereço do contrato SRT>');

--- a/exemplos/example3.ts
+++ b/exemplos/example3.ts
@@ -1,11 +1,6 @@
 import { ethers } from "hardhat";
 import abiRealTokenizado from '../abi/RealTokenizado.json';
-import { Transaction } from "ethers";
 import { TransactionReceipt, TransactionResponse } from "@ethersproject/providers";
-
-function delay(ms: number) {
-    return new Promise( resolve => setTimeout(resolve, ms) );
-};
 
 // Participante ativa um endereço para um cliente e realizando uma emissão de DVt ou MEt
 async function example3() {


### PR DESCRIPTION
Não acho válido dizer que deve-se esperar 1 bloco, pois nem sempre a transação é mintada em 1 bloco após o envio.
O jeito certo é dizer que deve esperar que a transação seja confirmada e seja válida `status === 1`. Assim teremos a mudança de estado desejada. 

Caso a transação falhe ou não exista, as transações seguintes que dependem do estado gerado por `enableAccount` irão falhar.