### PR TITLE
Corrige max-peers para suportar todos os nodes planejados

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,7 +30,7 @@ p2p-enabled=true
 discovery-enabled=true
 #p2p-host="0.0.0.0"
 p2p-port=30303
-max-peers=25
+max-peers=26
 
 host-allowlist=["*"]
 


### PR DESCRIPTION
Seguindo a definição do piloto:
16 participantes + 
4 validadores bcb + 
2 validadores selic + 
2 fullnodes bcb + 
2 fullnodes selic

O valor atual de 25 não permitirá comportar todos os nós planejados.